### PR TITLE
Don't toggle STOMT at every keypress when no toggle key is selected.

### DIFF
--- a/Scripts/StomtPopup.cs
+++ b/Scripts/StomtPopup.cs
@@ -132,7 +132,7 @@ namespace Stomt
 
         void OnGUI()
         {
-            if (Event.current.Equals(Event.KeyboardEvent(_toggleKey.ToString())))
+            if (Event.current.Equals(Event.KeyboardEvent(_toggleKey.ToString())) && _toggleKey != KeyCode.None)
             {
                 if (_ui.activeSelf)
                 {


### PR DESCRIPTION
Currently, if you selects "None" as the STOMT toggle key, every keypress toggles STOMT. This fixes that.